### PR TITLE
依赖改进

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ run
 *.test
 publish
 cocosupdate
+/vendor/
+/.idea/

--- a/channel/change.go
+++ b/channel/change.go
@@ -10,8 +10,8 @@ package channel
 import (
 	"os"
 
-	"github.com/leafsoar/cocosupdate/util"
-	"github.com/leafsoar/cocosupdate/version"
+	"cocosupdate/util"
+	"cocosupdate/version"
 )
 
 // Change 版本变化

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/leafsoar/cocosupdate/manifest"
-	"github.com/leafsoar/cocosupdate/util"
-	"github.com/leafsoar/cocosupdate/version"
+	"cocosupdate/manifest"
+	"cocosupdate/util"
+	"cocosupdate/version"
 )
 
 // Channel 渠道相关数据

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,8 @@
+hash: 1678e46c782e978c3a31b4ccd00624eb34e8477e2e71c81d7bd07f6747597f95
+updated: 2018-01-06T20:11:03.747429784+08:00
+imports:
+- name: github.com/codegangsta/cli
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
+- name: github.com/mcuadros/go-version
+  version: 88e56e02bea1c203c99222c365fa52a69996ccac
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,12 @@
+package: cocosupdate
+import:
+- package: github.com/codegangsta/cli
+  version: ~1.20.0
+- package: cocosupdate
+  version: ~0.3.3
+  subpackages:
+  - channel
+  - manifest
+  - util
+  - version
+- package: github.com/mcuadros/go-version

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"os/signal"
 	"strings"
 
-	"github.com/leafsoar/cocosupdate/channel"
+	"cocosupdate/channel"
 
 	"github.com/codegangsta/cli"
 )

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 // 根据源资源，生成发布资源
-func publish(address, assets, publish, name, engine string) {
+func publish(address, assets, publish, name, engine, scheme string) {
 	fmt.Println("开始生成发布资源 ...")
 	fmt.Println("资源目录: ", assets)
 	fmt.Println("发布目录: ", publish)
@@ -31,9 +31,9 @@ func publish(address, assets, publish, name, engine string) {
 		pubengine = engine
 	}
 	// 发布
-	ch.Publish("http://"+address, pubengine)
+	ch.Publish(scheme+"://"+address, pubengine)
 	fmt.Println("引擎版本: ", pubengine)
-	fmt.Printf("发布完成:  http://%s/%s\n", address, name)
+	fmt.Printf("发布完成:  "+scheme+"://%s/%s\n", address, name)
 }
 
 func startServer(port string, publish string) {
@@ -91,6 +91,11 @@ func main() {
 					Value: "3.7.1",
 					Usage: "cocos 引擎版本 (不指定时自动读取 project.manifest 值 || 3.7.1)",
 				},
+				cli.StringFlag{
+					Name:  "scheme, s",
+					Value: "http",
+					Usage: "协议类型, http 或 https, 默认 http",
+				},
 			},
 			Action: func(c *cli.Context) {
 				publish(
@@ -99,6 +104,7 @@ func main() {
 					c.String("publish"),
 					c.String("name"),
 					c.String("engine"),
+					c.String("scheme"),
 				)
 			},
 		},

--- a/version/version.go
+++ b/version/version.go
@@ -11,8 +11,8 @@ import (
 	fp "path/filepath"
 	"strings"
 
-	"github.com/leafsoar/cocosupdate/manifest"
-	"github.com/leafsoar/cocosupdate/util"
+	"cocosupdate/manifest"
+	"cocosupdate/util"
 )
 
 // Version 资源版本


### PR DESCRIPTION
## Change
* 修改了项目内的 import 路径, project 内部的依赖不需要使用绝对路径
比如 `import "github.com/leafsoar/cocosupdate/util"` 直接用 `cocosupdate/util` 就可以了, 不然反而会导致 fork 的项目修改不方便  
* 添加了 glide 用作外部依赖管理 `glide install` 可以自动安装依赖
* build 命令增加了 `scheme, s` 参数生成的 URL 可以使用 `https` 